### PR TITLE
Add support for configuring the border radius using theme var 

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ The following variables are available and can be set in your theme to change the
 | --sonos-accent-color | var(--accent-color)
 | --sonos-title-color | var(--card-background-color)
 | --sonos-border-radius | 0.25rem
-| --sonos-border-width | 0.5rem
+| --sonos-border-width | 0.125rem
 
 ## Linking to specific player
 Append `#media_player.my_sonos_player` to page URL to have that player selected. 

--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ The following variables are available and can be set in your theme to change the
 | --sonos-artist-album-text-color | var(--primary-text-color)
 | --sonos-accent-color | var(--accent-color)
 | --sonos-title-color | var(--card-background-color)
+| --sonos-border-radius | 0.25rem
+| --sonos-border-width | 0.5rem
 
 ## Linking to specific player
 Append `#media_player.my_sonos_player` to page URL to have that player selected. 

--- a/src/favorite-buttons.ts
+++ b/src/favorite-buttons.ts
@@ -58,7 +58,6 @@ class FavoriteButtons extends LitElement {
         flex-wrap: wrap;
       }
       .favorite {
-        overflow: hidden;
         width: 28%;
         max-width: 28%;
         border: 2px solid var(--sonos-int-background-color);
@@ -87,6 +86,7 @@ class FavoriteButtons extends LitElement {
         overflow: hidden;
         white-space: nowrap;
         background-color: var(--sonos-int-player-section-background);
+        border-radius: var(--sonos-int-border-radius) 0;
       }
       .favorite:focus,
       .favorite:hover {

--- a/src/favorite-buttons.ts
+++ b/src/favorite-buttons.ts
@@ -58,6 +58,7 @@ class FavoriteButtons extends LitElement {
         flex-wrap: wrap;
       }
       .favorite {
+        overflow: hidden;
         width: 28%;
         max-width: 28%;
         border: 2px solid var(--sonos-int-background-color);

--- a/src/favorite-buttons.ts
+++ b/src/favorite-buttons.ts
@@ -86,7 +86,7 @@ class FavoriteButtons extends LitElement {
         overflow: hidden;
         white-space: nowrap;
         background-color: var(--sonos-int-player-section-background);
-        border-radius: var(--sonos-int-border-radius) 0;
+        border-radius: calc(var(--sonos-int-border-radius) - 4px) calc(var(--sonos-int-border-radius) - 4px) 0 0;
       }
       .favorite:focus,
       .favorite:hover {

--- a/src/group.ts
+++ b/src/group.ts
@@ -52,16 +52,14 @@ class Group extends LitElement {
       }
       .group .wrap {
         border-radius: var(--sonos-int-border-radius);
-        margin: 2px;
+        margin: 5px 0;
         padding: 9px;
+        border: thin solid var(--sonos-int-background-color);
         background-color: var(--sonos-int-background-color);
         box-shadow: var(--sonos-int-box-shadow);
       }
       .group .wrap.active {
-        margin: 5px 0;
-        border-color: var(--sonos-int-accent-color);
-        border-width: thin;
-        border-style: solid;
+        border: thin solid var(--sonos-int-accent-color);
         font-weight: bold;
       }
       .group:first-child .wrap {

--- a/src/main.ts
+++ b/src/main.ts
@@ -199,6 +199,7 @@ export class CustomSonosCard extends LitElement {
         --sonos-int-accent-color: var(--sonos-accent-color, var(--accent-color));
         --sonos-int-title-color: var(--sonos-title-color, var(--card-background-color));
         --sonos-int-border-radius: var(--sonos-border-radius, 0.25rem);
+        --sonos-int-border-width: var(--sonos-border-width, 8px);
         --mdc-icon-size: 18px;
         color: var(--sonos-int-color);
       }

--- a/src/main.ts
+++ b/src/main.ts
@@ -216,7 +216,7 @@ export class CustomSonosCard extends LitElement {
       }
       .players {
         flex: 0 0 45%;
-        max-width: 45%;
+        max-width: 700px;
       }
       .content {
         display: flex;

--- a/src/main.ts
+++ b/src/main.ts
@@ -198,7 +198,7 @@ export class CustomSonosCard extends LitElement {
         --sonos-int-artist-album-text-color: var(--sonos-artist-album-text-color, var(--primary-text-color));
         --sonos-int-accent-color: var(--sonos-accent-color, var(--accent-color));
         --sonos-int-title-color: var(--sonos-title-color, var(--card-background-color));
-        --sonos-int-border-radius: 0.25rem;
+        --sonos-int-border-radius: var(--sonos-border-radius, 0.25rem);
         --mdc-icon-size: 18px;
         color: var(--sonos-int-color);
       }
@@ -237,7 +237,7 @@ export class CustomSonosCard extends LitElement {
         max-width: 25%;
       }
       .title {
-        margin-top: 10px;
+        margin-top: 10px 0;
         text-align: center;
         font-weight: bold;
         font-size: larger;

--- a/src/main.ts
+++ b/src/main.ts
@@ -199,7 +199,7 @@ export class CustomSonosCard extends LitElement {
         --sonos-int-accent-color: var(--sonos-accent-color, var(--accent-color));
         --sonos-int-title-color: var(--sonos-title-color, var(--card-background-color));
         --sonos-int-border-radius: var(--sonos-border-radius, 0.25rem);
-        --sonos-int-border-width: var(--sonos-border-width, 0.5rem);
+        --sonos-int-border-width: var(--sonos-border-width, 0.125rem);
         --mdc-icon-size: 18px;
         color: var(--sonos-int-color);
       }

--- a/src/main.ts
+++ b/src/main.ts
@@ -199,7 +199,7 @@ export class CustomSonosCard extends LitElement {
         --sonos-int-accent-color: var(--sonos-accent-color, var(--accent-color));
         --sonos-int-title-color: var(--sonos-title-color, var(--card-background-color));
         --sonos-int-border-radius: var(--sonos-border-radius, 0.25rem);
-        --sonos-int-border-width: var(--sonos-border-width, 8px);
+        --sonos-int-border-width: var(--sonos-border-width, 0.5rem);
         --mdc-icon-size: 18px;
         color: var(--sonos-int-color);
       }

--- a/src/main.ts
+++ b/src/main.ts
@@ -238,7 +238,7 @@ export class CustomSonosCard extends LitElement {
         max-width: 25%;
       }
       .title {
-        margin-top: 10px 0;
+        margin: 10px 0;
         text-align: center;
         font-weight: bold;
         font-size: larger;

--- a/src/main.ts
+++ b/src/main.ts
@@ -217,7 +217,7 @@ export class CustomSonosCard extends LitElement {
       }
       .players {
         flex: 0 0 45%;
-        max-width: 700px;
+        max-width: 45%;
       }
       .content {
         display: flex;

--- a/src/player.ts
+++ b/src/player.ts
@@ -146,7 +146,6 @@ class Player extends LitElement {
         position: relative;
         background: var(--sonos-int-background-color);
         border-radius: var(--sonos-int-border-radius);
-        border: 8px solid var(--sonos-int-background-color);
         box-shadow: var(--sonos-int-box-shadow);
         padding-bottom: 100%;
         background-position-x: center;
@@ -164,7 +163,8 @@ class Player extends LitElement {
 
       .footer {
         background: var(--sonos-int-player-section-background);
-        margin: 0.5rem;
+        margin: 0.25rem;
+        padding: 0.5rem;
         border-radius: var(--sonos-int-border-radius);
         overflow: hidden auto;
       }
@@ -195,7 +195,8 @@ class Player extends LitElement {
       }
 
       .info {
-        margin: 0.5rem;
+        margin: 0.25rem;
+        padding: 0.5rem;
         text-align: center;
         background: var(--sonos-int-player-section-background);
         border-radius: var(--sonos-int-border-radius);

--- a/src/player.ts
+++ b/src/player.ts
@@ -148,6 +148,7 @@ class Player extends LitElement {
         border-radius: var(--sonos-int-border-radius);
         box-shadow: var(--sonos-int-box-shadow);
         padding-bottom: 100%;
+        border: var(--sonos-int-border-width) solid var(--sonos-int-background-color);
         background-position-x: center;
         background-repeat: no-repeat;
         background-size: cover;


### PR DESCRIPTION
Hi, I've made some visual changes in the CSS. 
See if you like it. 

I've added another theme option name: sonos-border-radius

<img width="1440" alt="Schermafbeelding 2022-02-25 om 11 53 29" src="https://user-images.githubusercontent.com/67443916/155707262-4ce1c3a1-8fb5-4533-84ba-a66ab86bc5e3.png">
<img width="1440" alt="Schermafbeelding 2022-02-25 om 11 54 53" src="https://user-images.githubusercontent.com/67443916/155707324-96510797-5903-4d14-8219-2b24d744be08.png">

cheers.