### PR TITLE
Feature: new theme variable ‘sonos-favorites-multiline’

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ The following variables are available and can be set in your theme to change the
 | --sonos-title-color | var(--card-background-color)
 | --sonos-border-radius | 0.25rem
 | --sonos-border-width | 0.125rem
+| --sonos-favorites-multiline | nowrap
 
 ### Example
 Here is a themed version with more rounded corners,different accent color and no transparency (thanks @giuliandenicola1).

--- a/src/favorite-buttons.ts
+++ b/src/favorite-buttons.ts
@@ -61,7 +61,7 @@ class FavoriteButtons extends LitElement {
         flex-wrap: wrap;
       }
       .favorite-wrapper {
-        padding: 0.1rem 0.1rem 0.3rem;
+        padding: 0 .6rem 0.4rem 0;
         box-sizing: border-box;
       }
       .favorite {
@@ -79,9 +79,9 @@ class FavoriteButtons extends LitElement {
         background-repeat: no-repeat;
         background-size: cover;
         position: relative;
-        width: 95%;
+        width: 100%;
         height: 0;
-        padding-bottom: 95%;
+        padding-bottom: 100%;
       }
       .title {
         width: calc(100% - 0.2rem);

--- a/src/favorite-buttons.ts
+++ b/src/favorite-buttons.ts
@@ -65,6 +65,7 @@ class FavoriteButtons extends LitElement {
         box-sizing: border-box;
       }
       .favorite {
+        overflow: hidden;
         border: 0.1rem solid var(--sonos-int-background-color);
         display: flex;
         flex-direction: column;
@@ -83,19 +84,19 @@ class FavoriteButtons extends LitElement {
         padding-bottom: 95%;
       }
       .title {
-        width: 100%;
+        width: calc(100% - 0.2rem);
         text-align: center;
         font-size: 0.6rem;
         position: absolute;
-        top: 0;
-        left: 0;
+        top: 0.1rem;
+        left: 0.1rem;
       }
       .title-with-image {
         text-overflow: ellipsis;
         overflow: hidden;
-        white-space: nowrap;
+        white-space: var(--sonos-int-favorites-white-space);
         background-color: var(--sonos-int-player-section-background);
-        border-radius: calc(var(--sonos-int-border-radius) - 4px) calc(var(--sonos-int-border-radius) - 4px) 0 0;
+        border-radius: calc(var(--sonos-int-border-radius) - 0.25rem) calc(var(--sonos-int-border-radius) - 0.25rem) 0 0;
       }
       .favorite:focus,
       .favorite:hover {

--- a/src/favorite-buttons.ts
+++ b/src/favorite-buttons.ts
@@ -61,7 +61,7 @@ class FavoriteButtons extends LitElement {
         flex-wrap: wrap;
       }
       .favorite-wrapper {
-        padding: 0.1rem;
+        padding: 0.1rem 0.1rem 0.3rem;
         box-sizing: border-box;
       }
       .favorite {

--- a/src/group.ts
+++ b/src/group.ts
@@ -52,7 +52,7 @@ class Group extends LitElement {
       }
       .group .wrap {
         border-radius: var(--sonos-int-border-radius);
-        margin: 0.1rem 0;
+        margin: 0.5rem 0;
         padding: 0.5rem;
         border: thin solid var(--sonos-int-background-color);
         background-color: var(--sonos-int-background-color);

--- a/src/grouping-buttons.ts
+++ b/src/grouping-buttons.ts
@@ -74,7 +74,7 @@ class GroupingButtons extends LitElement {
       .member {
         flex-grow: 1;
         border-radius: var(--sonos-int-border-radius);
-        margin: 0.05rem;
+        margin: 0 0.25rem 0.5rem;
         padding: 0.45rem;
         display: flex;
         justify-content: center;

--- a/src/main.ts
+++ b/src/main.ts
@@ -181,6 +181,7 @@ export class CustomSonosCard extends LitElement {
         --sonos-int-title-color: var(--sonos-title-color, var(--card-background-color));
         --sonos-int-border-radius: var(--sonos-border-radius, 0.25rem);
         --sonos-int-border-width: var(--sonos-border-width, 0.125rem);
+        --sonos-int-favorites-white-space: var(--sonos-favorites-multiline, nowrap);
         --mdc-icon-size: 1rem;
         color: var(--sonos-int-color);
       }
@@ -207,7 +208,7 @@ export class CustomSonosCard extends LitElement {
         box-sizing: border-box;
       }
       .title {
-        margin-top: 0.5rem;
+        margin: 0.5rem 0;
         text-align: center;
         font-weight: bold;
         font-size: larger;


### PR DESCRIPTION
Hi, I've updated to 2.4.0 and the styling when having rounded corners were different like the roundings weren't fitting anymore. So I've modified it a little.

original
<img width="238" alt="Schermafbeelding 2022-02-26 om 14 16 32" src="https://user-images.githubusercontent.com/67443916/155844780-858f0338-afe5-4ccb-a1a6-ef50658ebda6.png">

modified
<img width="238" alt="Schermafbeelding 2022-02-26 om 14 17 41" src="https://user-images.githubusercontent.com/67443916/155844777-ab18fa19-19bc-44c4-8aec-e705e6533449.png">

I've also changed some spacing issues I had because I was already in the code. So why not?

original
<img width="1126" alt="Schermafbeelding 2022-02-26 om 14 25 15" src="https://user-images.githubusercontent.com/67443916/155844986-005d8f3a-8fa0-4ea8-ab8d-54f1bbeea124.png">
<img width="583" alt="Schermafbeelding 2022-02-26 om 14 24 03" src="https://user-images.githubusercontent.com/67443916/155844956-4903ec39-b2eb-41fc-bd37-d1d6170637fc.png">

modified
<img width="1126" alt="Schermafbeelding 2022-02-26 om 14 26 05" src="https://user-images.githubusercontent.com/67443916/155844989-6107ec30-6ee0-4b67-8dd9-84e4bbfe266b.png">
<img width="583" alt="Schermafbeelding 2022-02-26 om 14 23 25" src="https://user-images.githubusercontent.com/67443916/155844954-5694810d-7f54-4898-b13b-6410001c2020.png">

As seen on the screenshot below I've added the option to allow the title in the favorites tab to be multi line. This can be set in the theme file. default is 1 line anything else you put in it will make it multiline for example: `sonos-favorites-multiline: 'yes'`
<img width="1126" alt="Schermafbeelding 2022-02-26 om 14 27 39" src="https://user-images.githubusercontent.com/67443916/155845040-315fe765-bf7e-4e30-96ba-d86218ca6b20.png">

See if you can do anything with this!
Cheers