### PR TITLE
Improve browser backward compatibility

### DIFF
--- a/src/components/group.ts
+++ b/src/components/group.ts
@@ -14,7 +14,7 @@ class Group extends LitElement {
     const stateObj = this.hass.states[this.group];
     const currentTrack = `${stateObj.attributes.media_artist || ''} - ${
       stateObj.attributes.media_title || ''
-    }`.replaceAll(/^ - /g, '');
+    }`.replace(/^ - /g, '');
     return html`
       <div class="group">
         <div class="wrap ${this.activePlayer ? 'active' : ''}">

--- a/src/main.ts
+++ b/src/main.ts
@@ -141,7 +141,7 @@ export class CustomSonosCard extends LitElement {
   determineActivePlayer(playerGroups: PlayerGroups) {
     const selected_player =
       this.config.selectedPlayer ||
-      (window.location.href.indexOf('#') > 0 ? window.location.href.replaceAll(/.*#/g, '') : '');
+      (window.location.href.indexOf('#') > 0 ? window.location.href.split('#')[1] : '');
     if (this.activePlayer) {
       this.setActivePlayer(this.activePlayer);
     }
@@ -251,7 +251,7 @@ export class CustomSonosCard extends LitElement {
 
   setActivePlayer(player: string) {
     this.activePlayer = player;
-    const newUrl = window.location.href.replaceAll(/#.*/g, '');
+    const newUrl = window.location.href.split('#')[0];
     window.location.href = `${newUrl}#${player}`;
   }
 }


### PR DESCRIPTION
Fixes #52 
Removed the replaceAll function calls to improve browser backward compatibility.
As far as I have tested it, everything works. But happy to have another look over the changes.