### PR TITLE
Feature: Prefix for artwork path

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ customSources: # Main usecase is probably to set tv media player to play TV soun
       thumbnail: https://cdn-icons-png.flaticon.com/512/716/716429.png
 skipAdditionalPlayerSwitches: true # default is false, which means additional switches will be shown in player if available (such as crossfade button)
 disableDynamicVolumeSlider: true # default is false. See more in section further down.
+prefixArtwork: http://192.168.0.59:8123 #default is ''. This is your HA local IP-adress and is used to make the artwork work if you cast the dashboard with Google Cast.
 
 # sonos-media-browser specific
 mediaTitle: ''

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ customSources: # Main usecase is probably to set tv media player to play TV soun
       thumbnail: https://cdn-icons-png.flaticon.com/512/716/716429.png
 skipAdditionalPlayerSwitches: true # default is false, which means additional switches will be shown in player if available (such as crossfade button)
 disableDynamicVolumeSlider: true # default is false. See more in section further down.
-prefixArtwork: http://192.168.0.59:8123 #default is ''. This is your HA local IP-adress and is used to make the artwork work if you cast the dashboard with Google Cast.
+artworkHostname: http://192.168.0.59:8123 #default is ''. Usually not needed, but depending on your setup your device might not be able to access the artwork on the default host. One example where it could be needed is if you cast the dashboard with Google Cast.
 
 # sonos-media-browser specific
 mediaTitle: ''

--- a/src/cards/player.ts
+++ b/src/cards/player.ts
@@ -85,7 +85,8 @@ export class Player extends LitElement {
   }
 
   private containerStyle(entity: HassEntity) {
-    const entityImage = entity.attributes.entity_picture;
+    const prefix = this.config.prefixArtwork || '';
+    const entityImage = prefix + entity.attributes.entity_picture;
     const mediaTitle = entity.attributes.media_title;
     const mediaContentId = entity.attributes.media_content_id;
     let style: StyleInfo = {

--- a/src/cards/player.ts
+++ b/src/cards/player.ts
@@ -85,7 +85,7 @@ export class Player extends LitElement {
   }
 
   private containerStyle(entity: HassEntity) {
-    const prefix = this.config.prefixArtwork || '';
+    const prefix = this.config.artworkHostname || '';
     const entityImage = prefix + entity.attributes.entity_picture;
     const mediaTitle = entity.attributes.media_title;
     const mediaContentId = entity.attributes.media_content_id;

--- a/src/types.ts
+++ b/src/types.ts
@@ -39,6 +39,7 @@ export interface CardConfig extends LovelaceCardConfig {
   predefinedGroupsTitle?: string;
   predefinedGroupsNoSeparateSection?: boolean;
   mediaBrowserItemsAsList?: boolean;
+  prefixArtwork?: string;
 }
 
 export interface Layout {

--- a/src/types.ts
+++ b/src/types.ts
@@ -39,7 +39,7 @@ export interface CardConfig extends LovelaceCardConfig {
   predefinedGroupsTitle?: string;
   predefinedGroupsNoSeparateSection?: boolean;
   mediaBrowserItemsAsList?: boolean;
-  prefixArtwork?: string;
+  artworkHostname?: string;
 }
 
 export interface Layout {


### PR DESCRIPTION
## What?
I have made a new config type called prefixArtwork and a new way to make the path used for entityImage.

## Why?
I struggled with missing artwork when casting the custom-sonos-card to a NestHub. I figured out this has something to do with the path for the artwork. By adding a prefix with the HA IP address, as presented in the updated README, the artwork will show when casted. 

## Testing?
I have tested this and by adding the possibility to add a prefix I am now able to show the artwork when casting.

## Further work?
The best way would have been if the artwork would both show when casting or not. I have not found out how to this, but the standard "media-control" card in HA can.

## Anything else?
This is my first ever pull request and I am no TypeScript expert. Sorry if the proposed fix is bad written.